### PR TITLE
Destroy the worker when the component has been unmounted

### DIFF
--- a/packages/vue-pdf/src/components/VuePDF.vue
+++ b/packages/vue-pdf/src/components/VuePDF.vue
@@ -1,7 +1,7 @@
 <!-- eslint-disable no-case-declarations -->
 <script setup lang="ts">
 import * as PDFJS from 'pdfjs-dist'
-import { computed, onMounted, ref, toRaw, watch } from 'vue'
+import { computed, onMounted, onUnmounted, ref, toRaw, watch } from 'vue'
 
 import 'pdfjs-dist/web/pdf_viewer.css'
 
@@ -277,6 +277,11 @@ watch(() => [
 onMounted(() => {
   if (props.pdf !== undefined)
     initDoc(props.pdf)
+})
+
+onUnmounted(() => {
+  // Abort all network process and terminates the worker
+  props.pdf?.destroy()
 })
 
 // Exposed methods


### PR DESCRIPTION
Closes #130

This change could break some implementations. 

If the component rendering is conditionated by `v-if` and the condition is set to `false` the worker will be destroyed and the pages won't be rendered if the condition returns to `true`. To avoid this behavior replace `v-if` by `v-show` or ensure to change the `src` parameter on `usePDF` to reload the worker.