### PR TITLE
Overlay slot

### DIFF
--- a/packages/vue-pdf/src/components/VuePDF.vue
+++ b/packages/vue-pdf/src/components/VuePDF.vue
@@ -355,7 +355,7 @@ defineExpose({
       <slot />
     </div>
     <slot
-      name="footer"
+      name="overlay"
       :width="internalProps.viewport?.width"
       :height="internalProps.viewport?.height"
     />

--- a/packages/vue-pdf/src/components/VuePDF.vue
+++ b/packages/vue-pdf/src/components/VuePDF.vue
@@ -354,5 +354,10 @@ defineExpose({
     <div v-show="loading" ref="loadingLayer" style="position: absolute">
       <slot />
     </div>
+    <slot
+      name="footer"
+      :width="internalProps.viewport?.width"
+      :height="internalProps.viewport?.height"
+    />
   </div>
 </template>


### PR DESCRIPTION
add a second named slot to the template

this allows you do do things like:
```
<VuePDF :pdf="pdf" :page="page">
  <template #overlay="pageProps">
    <!-- an overlay canvas on top of the pdf -->
    <canvas :width="pageProps.width" :height="pageProps.height" />
  </template>
</VuePDF>
```