### PR TITLE
Fix memory leak when switching rapidly between pdf files

### DIFF
--- a/packages/vue-pdf/src/components/VuePDF.vue
+++ b/packages/vue-pdf/src/components/VuePDF.vue
@@ -284,7 +284,11 @@ function initDoc(proxy: PDFDocumentLoadingTask) {
 
 watch(
   () => props.pdf,
-  (pdf) => {
+  (pdf, oldPdf) => {
+    cancelRender();
+    if (oldPdf && oldPdf !== pdf && !props.autoDestroy) {
+      oldPdf.destroy();
+    }
     // For any changes on pdf, reinicialize all
     if (pdf !== undefined) initDoc(pdf);
   }

--- a/packages/vue-pdf/src/components/composable.ts
+++ b/packages/vue-pdf/src/components/composable.ts
@@ -51,6 +51,8 @@ export function usePDF(src: PDFSrc | Ref<PDFSrc>,
   const info = shallowRef<PDFInfo | {}>({})
 
   function processLoadingTask(source: PDFSrc) {
+    if (pdf.value)
+      void pdf.value.destroy()
     if (pdfDoc.value)
       void pdfDoc.value.destroy()
 
@@ -147,7 +149,7 @@ export function usePDF(src: PDFSrc | Ref<PDFSrc>,
   async function print(dpi = 150, filename = 'filename') {
     if (!pdf.value)
       throw new Error("Current PDFDocumentLoadingTask have not loaded yet");
-    
+
     const savedDocument = await pdf.value.promise;
 
     const PRINT_UNITS = dpi / 72


### PR DESCRIPTION
There was a memory leak when switching too quickly between multiple pdf files. See this comment: https://github.com/TaTo30/vue-pdf/issues/103#issuecomment-3356898221. 

The worker were not properly closed, when switching to a new file while the previous one was still loading.