### PR TITLE
Improve PDFWorker import + fix csp issue

### DIFF
--- a/packages/vue-pdf/src/components/composable.ts
+++ b/packages/vue-pdf/src/components/composable.ts
@@ -1,5 +1,5 @@
 import * as PDFJS from 'pdfjs-dist'
-import "pdfjs-dist/build/pdf.worker.mjs";
+import 'pdfjs-dist/build/pdf.worker.mjs';
 import { isRef, shallowRef, watch } from 'vue'
 
 import type { PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist'


### PR DESCRIPTION
Updated the import of PDFWorker to remove the need for manually setting workerSrc.
Info found in this issue: https://github.com/wojtekmaj/react-pdf/issues/1855#issuecomment-2670387509

This change also resolves a related Content Security Policy (CSP) issue where the PDF worker could not be loaded under strict CSP rules.
Issue: https://github.com/TaTo30/vue-pdf/issues/138
