### PR TITLE
create a new vite config for building a version without worker bundling, remove CommonJS format

### DIFF
--- a/packages/vue-pdf/package.json
+++ b/packages/vue-pdf/package.json
@@ -23,13 +23,16 @@
   "exports": {
     ".": {
       "types": "./dist/types/index.d.ts",
-      "require": "./dist/index.umd.js",
       "import": "./dist/index.mjs"
+    },
+    "./minimal": {
+      "types": "./dist/types/index.minimal.d.ts",
+      "import": "./dist/index.minimal.mjs"
     },
     "./style.css": "./dist/style.css",
     "./src/*": "./src/*"
   },
-  "main": "./dist/index.umd.js",
+  "main": "./dist/index.mjs",
   "module": "./dist/index.mjs",
   "types": "./dist/types/index.d.ts",
   "files": [
@@ -38,7 +41,7 @@
   ],
   "scripts": {
     "build": "npm run build:lib && npm run build:dts",
-    "build:lib": "vite build",
+    "build:lib": "vite build && vite --config vite.minimal.config.ts build --emptyOutDir=false",
     "build:dts": "vue-tsc --declaration --emitDeclarationOnly -p tsconfig.build.json",
     "lint": "eslint .",
     "lint:fix": "eslint --fix ."

--- a/packages/vue-pdf/src/components/composable.ts
+++ b/packages/vue-pdf/src/components/composable.ts
@@ -1,5 +1,4 @@
 import * as PDFJS from 'pdfjs-dist'
-import PDFWorker from 'pdfjs-dist/build/pdf.worker.min?url'
 import { isRef, shallowRef, watch } from 'vue'
 
 import type { PDFDocumentLoadingTask, PDFDocumentProxy } from 'pdfjs-dist'
@@ -8,12 +7,6 @@ import type { OnPasswordCallback, PDFDestination, PDFInfo, PDFOptions, PDFSrc } 
 import { getDestinationArray, getDestinationRef, getLocation, isSpecLike } from './utils/destination'
 import { addStylesToIframe, createIframe } from './utils/miscellaneous'
 
-// Could not find a way to make this work with vite, importing the worker entry bundle the whole worker to the the final output
-// https://erindoyle.dev/using-pdfjs-with-vite/
-// PDFJS.GlobalWorkerOptions.workerSrc = PDFWorker
-function configWorker(wokerSrc: string) {
-  PDFJS.GlobalWorkerOptions.workerSrc = wokerSrc
-}
 
 /**
  * @typedef {Object} UsePDFParameters
@@ -42,9 +35,6 @@ export function usePDF(src: PDFSrc | Ref<PDFSrc>,
     password: '',
   },
 ) {
-  if (!PDFJS.GlobalWorkerOptions?.workerSrc)
-    configWorker(PDFWorker)
-
   const pdf = shallowRef<PDFDocumentLoadingTask>()
   const pdfDoc = shallowRef<PDFDocumentProxy>()
   const pages = shallowRef(0)

--- a/packages/vue-pdf/src/index.minimal.ts
+++ b/packages/vue-pdf/src/index.minimal.ts
@@ -1,0 +1,11 @@
+import type { Plugin } from "vue";
+import VuePDF from "./components/VuePDF.vue";
+
+export const VuePDFPlugin: Plugin = {
+  install(Vue) {
+    Vue.component(VuePDF.name!, VuePDF);
+  },
+};
+
+export * from "./components";
+export default VuePDFPlugin;

--- a/packages/vue-pdf/src/index.ts
+++ b/packages/vue-pdf/src/index.ts
@@ -1,11 +1,20 @@
-import type { Plugin } from 'vue'
-import VuePDF from './components/VuePDF.vue'
+import { GlobalWorkerOptions } from "pdfjs-dist";
+import PDFWorker from "pdfjs-dist/build/pdf.worker.min?url";
+
+import type { Plugin } from "vue";
+import VuePDF from "./components/VuePDF.vue";
+
+function configWorker(wokerSrc: string) {
+  GlobalWorkerOptions.workerSrc = wokerSrc;
+}
+
+if (!GlobalWorkerOptions?.workerSrc) configWorker(PDFWorker);
 
 export const VuePDFPlugin: Plugin = {
   install(Vue) {
-    Vue.component(VuePDF.name, VuePDF)
+    Vue.component(VuePDF.name!, VuePDF)
   },
 }
 
-export * from './components'
+export * from "./components"
 export default VuePDFPlugin

--- a/packages/vue-pdf/vite.config.ts
+++ b/packages/vue-pdf/vite.config.ts
@@ -11,7 +11,8 @@ export default mergeConfig(
         entry: resolve(__dirname, './src/index.ts'),
         name: '@tato30/vue-pdf',
         fileName: 'index',
-        cssFileName: 'style'
+        cssFileName: 'style',
+        formats: ["es"]
       },
       rollupOptions: {
         external: ['vue', 'pdfjs-dist'],

--- a/packages/vue-pdf/vite.minimal.config.ts
+++ b/packages/vue-pdf/vite.minimal.config.ts
@@ -1,0 +1,29 @@
+import { resolve } from "node:path";
+import { defineConfig, mergeConfig } from "vite";
+import commonConfig from "../../vite.config";
+
+// https://vitejs.dev/config/
+export default mergeConfig(
+  commonConfig,
+  defineConfig({
+    build: {
+      lib: {
+        entry: resolve(__dirname, "./src/index.minimal.ts"),
+        name: "@tato30/vue-pdf",
+        fileName: "index.minimal",
+        cssFileName: "style",
+        formats: ["es"],
+      },
+      rollupOptions: {
+        external: ["vue", "pdfjs-dist"],
+        output: {
+          exports: "named",
+          globals: {
+            vue: "vue",
+            "pdfjs-dist": "PDFJS",
+          },
+        },
+      },
+    },
+  }),
+);


### PR DESCRIPTION
This enable an option for those who want reduced chunk size and handle worker configuration by themselves. Its usage is by importing the `minimal` entry and set the worker source properly, example:

```js
import { GlobalWorkerOptions } from "pdfjs-dist"
import { VuePDF, usePDF } from "@tato30/vue-pdf/minimal"

GlobalWorkerOptions.workerSrc = "https://unpkg.com/pdfjs-dist@5.4.296/build/pdf.worker.min.mjs"

// ...
```  