### PR TITLE
Re-export pdfjs

### DIFF
--- a/packages/vue-pdf/index.pdfjs.d.ts
+++ b/packages/vue-pdf/index.pdfjs.d.ts
@@ -1,0 +1,1 @@
+export * from "pdfjs-dist";

--- a/packages/vue-pdf/index.pdfjs.mjs
+++ b/packages/vue-pdf/index.pdfjs.mjs
@@ -1,0 +1,1 @@
+export * from "pdfjs-dist";

--- a/packages/vue-pdf/package.json
+++ b/packages/vue-pdf/package.json
@@ -29,6 +29,10 @@
       "types": "./dist/types/index.minimal.d.ts",
       "import": "./dist/index.minimal.mjs"
     },
+    "./pdfjs": {
+      "types": "./index.pdfjs.d.ts",
+      "import": "./index.pdfjs.mjs"
+    },
     "./style.css": "./dist/style.css",
     "./src/*": "./src/*"
   },
@@ -37,7 +41,9 @@
   "types": "./dist/types/index.d.ts",
   "files": [
     "dist",
-    "src"
+    "src",
+    "index.pdfjs.mjs",
+    "index.pdfjs.d.ts"
   ],
   "scripts": {
     "build": "npm run build:lib && npm run build:dts",


### PR DESCRIPTION
We are using our own loading tasks to load PDFs instead of `usePDF`. Since we disallow importing transitive dependencies, we currently have to add `pdfjs-dist` as a dependency, and always have to make sure its the exact same version as used by this library.

This PR adds a new export `pdfjs` that can be used to always import the exact pdfjs version used by this libary:
```ts
// import * as PDFJS from 'pdfjs-dist'
import * as PDFJS from '@tato30/vue-pdf/pdfjs';
```

I didn't add any build tasks for this and just added the two files needed for this to the package root, as they are so simple.

Thanks for this library, let me know what you think of this PR.

---

With minimal mode its not required to use the same version as this library, but it might still be nice for those not using minimal mode, even if it is just to import some types.